### PR TITLE
round batch size usign floor() and change order of start and end lr

### DIFF
--- a/R/lr-finder.R
+++ b/R/lr-finder.R
@@ -3,7 +3,7 @@ lr_anneal <- torch::lr_scheduler(
   initialize = function(
     optimizer,
     start_lr = 1e-7,
-    end_lr = 1e-4,
+    end_lr = 1e-1,
     n_iters = 100,
     last_epoch=-1,
     verbose=FALSE) {
@@ -45,8 +45,8 @@ luz_callback_record_lr <- luz_callback(
 #' @param object An nn_module that has been setup().
 #' @param data (dataloader) A dataloader created with torch::dataloader()  used for learning rate finding.
 #' @param steps (integer) The number of steps to iterate over in the learning rate finder. Default: 100.
-#' @param start_lr (float) The largest learning rate. Default: 1e-1.
-#' @param end_lr (float) The lowest learning rate. Default: 1e-7.
+#' @param start_lr (float) The smallest learning rate. Default: 1e-7.
+#' @param end_lr (float) The highest learning rate. Default: 1e-1.
 #' @param ... Other arguments passed to `fit`.
 #'
 #' @examples
@@ -65,9 +65,9 @@ luz_callback_record_lr <- luz_callback(
 #' }
 #' @returns A dataframe with two columns: learning rate and loss
 #' @export
-lr_finder <- function(object, data, steps = 100, start_lr = 1e-1, end_lr = 1e-7, ...) {
+lr_finder <- function(object, data, steps = 100, start_lr = 1e-7, end_lr = 1e-1, ...) {
   # adjust batch size so that the steps number adds to one batch
-  new_bs <- data$dataset$.length() / steps
+  new_bs <- floor(data$dataset$.length() / steps)
   data$batch_sampler$batch_size <- new_bs
 
   scheduler <- luz_callback_lr_scheduler(

--- a/man/lr_finder.Rd
+++ b/man/lr_finder.Rd
@@ -4,7 +4,7 @@
 \alias{lr_finder}
 \title{Learning Rate Finder}
 \usage{
-lr_finder(object, data, steps = 100, start_lr = 0.1, end_lr = 1e-07, ...)
+lr_finder(object, data, steps = 100, start_lr = 1e-07, end_lr = 0.1, ...)
 }
 \arguments{
 \item{object}{An nn_module that has been setup().}
@@ -13,9 +13,9 @@ lr_finder(object, data, steps = 100, start_lr = 0.1, end_lr = 1e-07, ...)
 
 \item{steps}{(integer) The number of steps to iterate over in the learning rate finder. Default: 100.}
 
-\item{start_lr}{(float) The largest learning rate. Default: 1e-1.}
+\item{start_lr}{(float) The smallest learning rate. Default: 1e-7.}
 
-\item{end_lr}{(float) The lowest learning rate. Default: 1e-7.}
+\item{end_lr}{(float) The highest learning rate. Default: 1e-1.}
 
 \item{...}{Other arguments passed to \code{fit}.}
 }


### PR DESCRIPTION
floor() fixes a problem with dataset length not being divisible by the number of steps (resulted in batch size = dataset length and lots of CUDA memory issues for me!)

I accidentally made my original PR using annealing from high LR to low LR. It should be the other way around. Now fixed.