### PR TITLE
Update learning rate exponentially and maybe, add smoothing to loss plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Many wording improvements in the getting started guides (#81, @jonthegeek).
 * Added MixUp callback and helper loss function and functional logic. (#82, @skeydan).
+* `lr_finder()` now by default divides the range between `start_lr` and `end_lr` into log-spaced intervals, following the fast.ai implementation. Cf. Sylvain Gugger's post: https://sgugger.github.io/how-do-you-find-a-good-learning-rate.html. The previous behavior can be achieved passing `log_spaced_intervals=FALSE` to the function. (#82, @skeydan)
+* `plot.lr_records()` now in addition plots an exponentially weighted moving average of the loss (again, see Sylvain Gugger's post), with a weighting coefficient of `0.9` (which seems a reasonable value for the default setting of 100 learning-rate-incrementing intervals). (#82, @skeydan)
 
 # luz 0.2.0
 

--- a/R/lr-finder.R
+++ b/R/lr-finder.R
@@ -101,9 +101,25 @@ print.lr_records <- function(x, ...) {
 }
 
 #' @export
-plot.lr_records <- function(x, ...) {
+plot.lr_records <- function(x, smoothed_loss = TRUE, beta = 0.98, ...) {
   rlang::check_installed("ggplot2")
-  x <- as.data.frame(x)
+
+  if(smoothed_loss) {
+
+    new_x <- data.frame(lr = x$lr, loss = rep(0, nrow(x)))
+    loss_exp_avg <- 0
+
+    for (i in 1:nrow(new_x)) {
+      loss_exp_avg <- beta * loss_exp_avg + (1 - beta) * x$loss[i]
+      new_x$loss[i] <- loss_exp_avg / (1 - beta^i)
+    }
+
+    x <- new_x
+
+  } else {
+    x <- as.data.frame(x)
+  }
+
   ggplot2::ggplot(x, ggplot2::aes_string(x = "lr", y = "loss")) +
     ggplot2::geom_line() +
     ggplot2::scale_x_log10() +

--- a/R/lr-finder.R
+++ b/R/lr-finder.R
@@ -12,6 +12,7 @@ lr_anneal <- torch::lr_scheduler(
     self$end_lr <- end_lr
     self$base_lrs <- start_lr
     self$iters <- n_iters
+    self$multiplier <- (end_lr/start_lr)^(1/n_iters)
 
     super$initialize(optimizer, last_epoch, verbose)
 
@@ -20,7 +21,7 @@ lr_anneal <- torch::lr_scheduler(
     if (self$last_epoch > 0) {
       lrs <- numeric(length(self$optimizer$param_groups))
       for (i in seq_along(self$optimizer$param_groups)) {
-        lrs[i] <- self$optimizer$param_groups[[i]]$lr * (self$end_lr / self$optimizer$param_groups[[i]]$lr) ^ (self$last_epoch / self$iters)
+        lrs[i] <- self$optimizer$param_groups[[i]]$lr * self$multiplier
       }
     } else {
       lrs <- as.numeric(self$base_lrs)

--- a/R/lr-finder.R
+++ b/R/lr-finder.R
@@ -5,6 +5,7 @@ lr_anneal <- torch::lr_scheduler(
     start_lr = 1e-7,
     end_lr = 1e-1,
     n_iters = 100,
+    log_spaced_intervals = TRUE,
     last_epoch=-1,
     verbose=FALSE) {
 
@@ -13,6 +14,7 @@ lr_anneal <- torch::lr_scheduler(
     self$base_lrs <- start_lr
     self$iters <- n_iters
     self$multiplier <- (end_lr/start_lr)^(1/n_iters)
+    self$log_spaced_intervals <- log_spaced_intervals
 
     super$initialize(optimizer, last_epoch, verbose)
 
@@ -21,7 +23,12 @@ lr_anneal <- torch::lr_scheduler(
     if (self$last_epoch > 0) {
       lrs <- numeric(length(self$optimizer$param_groups))
       for (i in seq_along(self$optimizer$param_groups)) {
-        lrs[i] <- self$optimizer$param_groups[[i]]$lr * self$multiplier
+        if (self$log_spaced_intervals) {
+          lrs[i] <- self$optimizer$param_groups[[i]]$lr * self$multiplier
+        } else {
+          lrs[i] <- self$optimizer$param_groups[[i]]$lr * (self$end_lr / self$optimizer$param_groups[[i]]$lr) ^ (self$last_epoch / self$iters)
+        }
+
       }
     } else {
       lrs <- as.numeric(self$base_lrs)
@@ -48,6 +55,7 @@ luz_callback_record_lr <- luz_callback(
 #' @param steps (integer) The number of steps to iterate over in the learning rate finder. Default: 100.
 #' @param start_lr (float) The smallest learning rate. Default: 1e-7.
 #' @param end_lr (float) The highest learning rate. Default: 1e-1.
+#' @param log_spaced_intervals (logical) Whether to divide the range between start_lr and end_lr into log-spaced intervals (alternative: uniform intervals). Default: TRUE
 #' @param ... Other arguments passed to `fit`.
 #'
 #' @examples
@@ -66,7 +74,7 @@ luz_callback_record_lr <- luz_callback(
 #' }
 #' @returns A dataframe with two columns: learning rate and loss
 #' @export
-lr_finder <- function(object, data, steps = 100, start_lr = 1e-7, end_lr = 1e-1, ...) {
+lr_finder <- function(object, data, steps = 100, start_lr = 1e-7, end_lr = 1e-1, log_spaced_intervals = TRUE, ...) {
   # adjust batch size so that the steps number adds to one batch
   new_bs <- floor(data$dataset$.length() / steps)
   data$batch_sampler$batch_size <- new_bs
@@ -77,6 +85,7 @@ lr_finder <- function(object, data, steps = 100, start_lr = 1e-7, end_lr = 1e-1,
     start_lr = start_lr,
     end_lr = end_lr,
     n_iters = steps,
+    log_spaced_intervals = log_spaced_intervals,
     call_on="on_train_batch_begin"
   )
 
@@ -102,27 +111,22 @@ print.lr_records <- function(x, ...) {
 }
 
 #' @export
-plot.lr_records <- function(x, smoothed_loss = TRUE, beta = 0.98, ...) {
+plot.lr_records <- function(x, ...) {
   rlang::check_installed("ggplot2")
 
-  if(smoothed_loss) {
+  x <- as.data.frame(x)
 
-    new_x <- data.frame(lr = x$lr, loss = rep(0, nrow(x)))
-    loss_exp_avg <- 0
+  loss_exp_avg <- 0
+  beta <- 0.9
 
-    for (i in 1:nrow(new_x)) {
-      loss_exp_avg <- beta * loss_exp_avg + (1 - beta) * x$loss[i]
-      new_x$loss[i] <- loss_exp_avg / (1 - beta^i)
-    }
-
-    x <- new_x
-
-  } else {
-    x <- as.data.frame(x)
+  for (i in 1:nrow(x)) {
+    loss_exp_avg <- beta * loss_exp_avg + (1 - beta) * x$loss[i]
+    x$smoothed_loss[i] <- loss_exp_avg / (1 - beta^i)
   }
 
-  ggplot2::ggplot(x, ggplot2::aes_string(x = "lr", y = "loss")) +
-    ggplot2::geom_line() +
+  ggplot2::ggplot(x, ggplot2::aes_string(x = "lr")) +
+    ggplot2::geom_line(ggplot2::aes_string(y = "loss")) +
+    ggplot2::geom_line(ggplot2::aes_string(y = "smoothed_loss"), color="cyan", alpha = 0.3, size = 3) +
     ggplot2::scale_x_log10() +
     ggplot2::xlab("Learning Rate") +
     ggplot2::ylab("Loss")

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -60,7 +60,7 @@ For example:\if{html}{\out{<div class="sourceCode r">}}\preformatted{evaluation 
 metrics <- get_metrics(evaluation)
 print(evaluation)
 }\if{html}{\out{</div>}}\preformatted{## A `luz_module_evaluation`
-## -- Results ----------------------------------------------------------------------------------
+## -- Results ---------------------------------------------------------------------
 ## loss: 1.8892
 ## mae: 1.0522
 ## mse: 1.645

--- a/man/lr_finder.Rd
+++ b/man/lr_finder.Rd
@@ -4,7 +4,15 @@
 \alias{lr_finder}
 \title{Learning Rate Finder}
 \usage{
-lr_finder(object, data, steps = 100, start_lr = 1e-07, end_lr = 0.1, ...)
+lr_finder(
+  object,
+  data,
+  steps = 100,
+  start_lr = 1e-07,
+  end_lr = 0.1,
+  log_spaced_intervals = TRUE,
+  ...
+)
 }
 \arguments{
 \item{object}{An nn_module that has been setup().}
@@ -16,6 +24,8 @@ lr_finder(object, data, steps = 100, start_lr = 1e-07, end_lr = 0.1, ...)
 \item{start_lr}{(float) The smallest learning rate. Default: 1e-7.}
 
 \item{end_lr}{(float) The highest learning rate. Default: 1e-1.}
+
+\item{log_spaced_intervals}{(logical) Whether to divide the range between start_lr and end_lr into log-spaced intervals (alternative: uniform intervals). Default: TRUE}
 
 \item{...}{Other arguments passed to \code{fit}.}
 }


### PR DESCRIPTION
First proposal of implementing a smoothed display of the loss, as done here: https://sgugger.github.io/how-do-you-find-a-good-learning-rate.html and (1:1 translation to R) here: https://blogs.rstudio.com/ai/posts/2020-10-19-torch-image-classification/.

From practical experience, this should be more helpful to most users.

Implementation-wise, it seems like it has to go into `plot.lr_records`, in which case I don't really know how we would want to make it configurable (in a useful way) ... For now, just so one can compare, I've added arguments `smoothed_loss` and `beta` to this method.

Here are example plots of smoothed vs. non-smoothed loss:

```
> df <- data.frame(lr = exp(1:100), loss=rep(c(150, 1000, 50, 10, 1), 20))
> plot.lr_records(df, smoothed_loss = FALSE)
> plot.lr_records(df)
```

![image](https://user-images.githubusercontent.com/469371/143049763-e48988a4-0712-49c4-9625-3da1d362ca4d.png)

![image](https://user-images.githubusercontent.com/469371/143049813-c3b3006f-4ab7-4dee-a438-cae69fc2e5f0.png)

What do you think Daniel?

