### PR TITLE
Add backward argument to `setup`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * `lr_finder()` now by default divides the range between `start_lr` and `end_lr` into log-spaced intervals, following the fast.ai implementation. Cf. Sylvain Gugger's post: https://sgugger.github.io/how-do-you-find-a-good-learning-rate.html. The previous behavior can be achieved passing `log_spaced_intervals=FALSE` to the function. (#82, @skeydan)
 * `plot.lr_records()` now in addition plots an exponentially weighted moving average of the loss (again, see Sylvain Gugger's post), with a weighting coefficient of `0.9` (which seems a reasonable value for the default setting of 100 learning-rate-incrementing intervals). (#82, @skeydan)
 * Added a `luz_callback_gradient_clip` inspired by FastAI's implementation. (#90)
+* Added a `backward` argument to `setup` allowing one to customize how `backward` is called for the loss scalar value. (#93)
 
 # luz 0.2.0
 

--- a/R/module.R
+++ b/R/module.R
@@ -19,7 +19,8 @@
 #' it's parameter. It must call `$backward()` or [torch::autograd_backward()].
 #' In general you don't need to set this parameter unless you need to customize
 #' how luz calls the `backward()`, for example, if you need to add additional
-#' arguments to the backward call.
+#' arguments to the backward call. Note that this becomes a method of the `nn_module`
+#' thus can be used by your custom `step()` if you override it.
 #'
 #' @returns
 #' A luz module that can be trained with [fit()].

--- a/man/setup.Rd
+++ b/man/setup.Rd
@@ -24,7 +24,8 @@ the training procedure.}
 it's parameter. It must call \verb{$backward()} or \code{\link[torch:autograd_backward]{torch::autograd_backward()}}.
 In general you don't need to set this parameter unless you need to customize
 how luz calls the \code{backward()}, for example, if you need to add additional
-arguments to the backward call.}
+arguments to the backward call. Note that this becomes a method of the \code{nn_module}
+thus can be used by your custom \code{step()} if you override it.}
 }
 \value{
 A luz module that can be trained with \code{\link[=fit]{fit()}}.

--- a/man/setup.Rd
+++ b/man/setup.Rd
@@ -4,7 +4,7 @@
 \alias{setup}
 \title{Set's up a \code{nn_module} to use with luz}
 \usage{
-setup(module, loss = NULL, optimizer = NULL, metrics = NULL)
+setup(module, loss = NULL, optimizer = NULL, metrics = NULL, backward = NULL)
 }
 \arguments{
 \item{module}{(\code{nn_module}) The \code{nn_module} that you want set up.}
@@ -19,6 +19,12 @@ the model parameters.}
 
 \item{metrics}{(\code{list}, optional) A list of metrics to be tracked during
 the training procedure.}
+
+\item{backward}{(\code{function}) A functions that takes the loss scalar values as
+it's parameter. It must call \verb{$backward()} or \code{\link[torch:autograd_backward]{torch::autograd_backward()}}.
+In general you don't need to set this parameter unless you need to customize
+how luz calls the \code{backward()}, for example, if you need to add additional
+arguments to the backward call.}
 }
 \value{
 A luz module that can be trained with \code{\link[=fit]{fit()}}.

--- a/tests/testthat/test-module.R
+++ b/tests/testthat/test-module.R
@@ -302,3 +302,29 @@ test_that("evaluate works", {
   expect_snapshot(print(e))
 })
 
+test_that("cutom backward", {
+
+  model <- get_model()
+  dl <- get_dl()
+
+  mod <- model %>%
+    setup(
+      loss = torch::nn_mse_loss(),
+      optimizer = torch::optim_adam,
+      backward = function(x) {
+        x$backward()
+        if (ctx$iter == 1 && ctx$epoch == 1) {
+          print("hello")
+        }
+      }
+    )
+
+  expect_s3_class(mod, "luz_module_generator")
+
+  expect_output(regexp = "hello", {
+    output <- mod %>%
+      set_hparams(input_size = 10, output_size = 1) %>%
+      fit(dl, valid_data = dl, verbose = FALSE)
+  })
+  expect_s3_class(output, "luz_module_fitted")
+})


### PR DESCRIPTION
This allows one to customize how to call `backward()`, for example, if you want to call backward with `create_graph=TRUE` you can use:

```
mod <- model %>%
    setup(
      loss = torch::nn_mse_loss(),
      optimizer = torch::optim_adam,
      backward = function(x) {
        x$backward(create_graph = TRUE)
      }
    )
```