### PR TITLE
progress bar for `lr_finder`.

### DIFF
--- a/R/lr-finder.R
+++ b/R/lr-finder.R
@@ -76,6 +76,7 @@ luz_callback_record_lr <- luz_callback(
 #' @param end_lr (float) The highest learning rate. Default: 1e-1.
 #' @param log_spaced_intervals (logical) Whether to divide the range between start_lr and end_lr into log-spaced intervals (alternative: uniform intervals). Default: TRUE
 #' @param ... Other arguments passed to `fit`.
+#' @param verbose Wether to show a progress bar during the process.
 #'
 #' @examples
 #' if (torch::torch_is_installed()) {

--- a/man/lr_finder.Rd
+++ b/man/lr_finder.Rd
@@ -11,7 +11,8 @@ lr_finder(
   start_lr = 1e-07,
   end_lr = 0.1,
   log_spaced_intervals = TRUE,
-  ...
+  ...,
+  verbose = NULL
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ lr_finder(
 \item{log_spaced_intervals}{(logical) Whether to divide the range between start_lr and end_lr into log-spaced intervals (alternative: uniform intervals). Default: TRUE}
 
 \item{...}{Other arguments passed to \code{fit}.}
+
+\item{verbose}{Wether to show a progress bar during the process.}
 }
 \value{
 A dataframe with two columns: learning rate and loss


### PR DESCRIPTION
Better support for verbose in `lr_finder`. No longer display 1 of 9999999 epochs.