### PR TITLE
Context aliases

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -81,7 +81,7 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
   GPU:
-    runs-on: ['self-hosted', 'gpu']
+    runs-on: ['self-hosted', 'gce', 'gpu']
     name: 'gpu'
 
     container:

--- a/.github/workflows/test-coverage-pak.yaml
+++ b/.github/workflows/test-coverage-pak.yaml
@@ -13,7 +13,7 @@ name: test-coverage
 jobs:
   test-coverage:
 
-    runs-on: ['self-hosted', 'gpu']
+    runs-on: ['self-hosted', 'gce', 'gpu']
 
     container:
       image: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu18.04

--- a/R/context.R
+++ b/R/context.R
@@ -332,14 +332,30 @@ context <- R6::R6Class(
     },
     #' @field opt Current optimizer.
     opt = function(new) {
-      if (missing(new))
-        return(private$.opt)
+      if (missing(new)) {
+        if (!is.null(private$.opt)) {
+          return(private$.opt)
+        } else {
+          if (length(self$optimizers) == 1) {
+            return(self$optimizers[[1]])
+          }
+        }
+        cli::cli_abort("{.var ctx$opt} not set.")
+      }
       private$.opt <- new
     },
     #' @field opt_name Current optimizer name.
     opt_name = function(new) {
-      if (missing(new))
-        return(private$.opt_name)
+      if (missing(new)) {
+        if (!is.null(private$.opt_name)) {
+          return(private$.opt_name)
+        } else {
+          if (length(self$optimizers) == 1) {
+            return(names(self$optimizers))
+          }
+        }
+        cli::cli_abort("{.var ctx$opt_name} not set.")
+      }
       private$.opt_name <- new
     },
     #' @field data Current dataloader in use.


### PR DESCRIPTION
Make `opt` and `opt_name` default aliases when there's a single optimizer, and they are not set. Allows for slighly for elegant `step()` functions.