### PR TITLE
Device method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ License: MIT + file LICENSE
 URL: https://mlverse.github.io/luz/, https://github.com/mlverse/luz
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Imports: 
     torch (>= 0.9.0),
     magrittr,

--- a/R/module.R
+++ b/R/module.R
@@ -24,6 +24,13 @@
 #' arguments to the backward call. Note that this becomes a method of the `nn_module`
 #' thus can be used by your custom `step()` if you override it.
 #'
+#' @note
+#' It also adds a `device` active field that can be used to query the current
+#' module `device` within methods, with eg `self$device`. This is useful when
+#' [ctx()] is not available, eg, when calling methods from outside the `luz`
+#' wrappers. Users can override the default by implementing a `device` active
+#' method in the input `module`.
+#'
 #' @returns
 #' A luz module that can be trained with [fit()].
 #'
@@ -73,9 +80,17 @@ setup <- function(module, loss = NULL, optimizer = NULL, metrics = NULL,
     luz_metric_set(metrics)
   }
 
-  methods$active <- list(device = function() {
-    self$parameters[[1]]$device
-  })
+  # adds a device method, allowing users to quickly query the current
+  # model device. this returns the device of the first parameter. should
+  # be OK to do it, as users there's current no support for multi-gpu
+  # training. users can override by implementing their own device method.
+  if (is.null(get_method(module, "device"))) {
+    methods$active <- list(
+      device = function() {
+        self$parameters[[1]]$device
+      }
+    )
+  }
 
   if (!has_forward_method(module))
     methods$forward <- identity

--- a/R/module.R
+++ b/R/module.R
@@ -73,6 +73,10 @@ setup <- function(module, loss = NULL, optimizer = NULL, metrics = NULL,
     luz_metric_set(metrics)
   }
 
+  methods$active <- list(device = function() {
+    self$parameters[[1]]$device
+  })
+
   if (!has_forward_method(module))
     methods$forward <- identity
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,14 +30,21 @@ has_method <- function(x, name) {
     FALSE
 }
 
+get_method <- function(x, method) {
+  if (!is.null(x$public_methods[[method]]))
+    x$public_methods[[method]]
+  else if (!is.null(x$get_inherit()))
+    get_method(x$get_inherit())
+  else
+    NULL
+}
 
 get_forward <- function(x) {
-  if (!is.null(x$public_methods[["forward"]]))
-    x$public_methods[["forward"]]
-  else if (!is.null(x$get_inherit()))
-    get_forward(x$get_inherit())
-  else
-    rlang::abort("No `forward` method found.")
+  forward <- get_method(x, "forward")
+  if (is.null(forward)) {
+    cli::cli_abort("No method {.val forward} method found.")
+  }
+  forward
 }
 
 has_forward_method <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,7 @@ get_method <- function(x, method) {
   if (!is.null(x$public_methods[[method]]))
     x$public_methods[[method]]
   else if (!is.null(x$get_inherit()))
-    get_method(x$get_inherit())
+    get_method(x$get_inherit(), method)
   else
     NULL
 }

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -65,11 +65,11 @@ print(evaluation)
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## A `luz_module_evaluation`
-## -- Results ---------------------------------------------------------------------------
-## loss: 1.8892
-## mae: 1.0522
-## mse: 1.645
-## rmse: 1.2826
+## -- Results ---------------------------------------------------------------------
+## loss: 1.5146
+## mae: 1.0251
+## mse: 1.5159
+## rmse: 1.2312
 }\if{html}{\out{</div>}}
 }
 \seealso{

--- a/man/luz_metric.Rd
+++ b/man/luz_metric.Rd
@@ -44,13 +44,13 @@ In order to implement a new \code{luz_metric} we need to implement 3 methods:
 \item \code{initialize}: defines the metric initial state. This function is
 called for each epoch for both training and validation loops.
 \item \code{update}: updates the metric internal state. This function is called
-at every training and validation step with the predictions obtained
-by the model and the target values obtained from the dataloader.
+at every training and validation step with the predictions obtained by
+the model and the target values obtained from the dataloader.
 \item \code{compute}: uses the internal state to compute metric values. This
 function is called whenever we need to obtain the current metric
 value. Eg, it’s called every training step for metrics displayed in
-the progress bar, but only called once per epoch to record it’s
-value when the progress bar is not displayed.
+the progress bar, but only called once per epoch to record it’s value
+when the progress bar is not displayed.
 }
 
 Optionally, you can implement an \code{abbrev} field that gives the metric an

--- a/man/setup.Rd
+++ b/man/setup.Rd
@@ -39,6 +39,13 @@ to be used with luz.
 \details{
 It makes sure the module have all the necessary ingredients in order to be fitted.
 }
+\note{
+It also adds a \code{device} active field that can be used to query the current
+module \code{device} within methods, with eg \code{self$device}. This is useful when
+\code{\link[=ctx]{ctx()}} is not available, eg, when calling methods from outside the \code{luz}
+wrappers. Users can override the default by implementing a \code{device} active
+method in the input \code{module}.
+}
 \seealso{
 Other training: 
 \code{\link{evaluate}()},

--- a/tests/testthat/test-module.R
+++ b/tests/testthat/test-module.R
@@ -328,3 +328,19 @@ test_that("cutom backward", {
   })
   expect_s3_class(output, "luz_module_fitted")
 })
+
+test_that("luz module has a device arg", {
+
+  mod <- get_model() %>%
+    setup(
+      loss = torch::nn_mse_loss(),
+      optimizer = torch::optim_adam
+    )
+
+  modul <- mod(1,1)
+
+  expect_true(
+    modul$device == torch_device("cpu")
+  )
+
+})

--- a/tests/testthat/test-module.R
+++ b/tests/testthat/test-module.R
@@ -343,4 +343,27 @@ test_that("luz module has a device arg", {
     modul$device == torch_device("cpu")
   )
 
+  mod <- nn_module(
+    initialize = function() {
+      self$par <- torch::nn_parameter(torch_randn(10, 10))
+    },
+    forward = function(x) {
+      self$par
+    },
+    active = list(
+      device = function() {
+        "hello"
+      }
+    )
+  )
+
+  model <- mod %>%
+    setup(
+      loss = torch::nn_mse_loss(),
+      optimizer = torch::optim_adam
+    )
+
+  modul <- mod()
+  expect_equal(modul$device, "hello")
+
 })


### PR DESCRIPTION
This adds a `device` active method so users can query the `device` from models even without luz contexts.