### PR TITLE
Drop last

### DIFF
--- a/R/module.R
+++ b/R/module.R
@@ -528,6 +528,11 @@ apply_dataloader_options <- function(data, valid_data, dataloader_options) {
     if (is.null(train_dl_options$shuffle))
       train_dl_options$shuffle <- TRUE
 
+    # It's usually better to drop the last batch if its not the same size as the
+    # other as it can have a large effect on results but based on very few obs.
+    if (is.null(train_dl_options$drop_last))
+      train_dl_options$drop_last <- TRUE
+
     data <- rlang::exec(as_dataloader, x = data, !!!train_dl_options)
   }
 

--- a/tests/testthat/_snaps/metrics.md
+++ b/tests/testthat/_snaps/metrics.md
@@ -13,7 +13,7 @@
     Error while calling callback with class <metrics_callback/LuzCallback/R6> at on_train_end.
     Caused by error in `self$call_compute_on_metric()`:
     ! Error when evaluating compute for metric with abbrev "h" and class <hello/LuzMetric/R6>
-    i The error happened at iter 32 of epoch 1.
+    i The error happened at iter 31 of epoch 1.
     i The model was in training mode.
     Caused by error in `metric$compute()`:
     ! Error computing metric.


### PR DESCRIPTION
It's usually better default to drop the last batch when training if it doesn't have the same size as data. Otherwise the last batch observations can have stronger influence on weights.