### PR TITLE
Bind context to the `.__enclos_env__`.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -55,7 +55,7 @@ has_forward_method <- function(x) {
 }
 
 bind_context <- function(x, ctx) {
-  e <- rlang::fn_env(x$clone) # the `clone` method must always exist in R6 classes
+  e <- x$.__enclos_env__
   rlang::env_bind(e, ctx = ctx)
 
   if (!is.null(x <- x$.__enclos_env__$super))


### PR DESCRIPTION
Better to bind the context directly into the `.__enclos_env__`, as with torch dev `clone` is just a static method.