### PR TITLE
Add scheduler reduce on plateau

### DIFF
--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -436,6 +436,7 @@ luz_callback_lr_scheduler <- luz_callback(
     }
     self[[call_on]] <- function() {
       if ("metrics" %in% names(formals(self$scheduler$step))) {
+        current_loss <- ctx$loss[[self$opt_name]]
         self$scheduler$step(current_loss)
       } else {
         self$scheduler$step()

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -436,9 +436,9 @@ luz_callback_lr_scheduler <- luz_callback(
     }
     self[[call_on]] <- function() {
       if ("metrics" %in% names(formals(scheduler$step))) {
-        scheduler$step(current_loss)
+        self$scheduler$step(current_loss)
       } else {
-        scheduler$step()
+        self$scheduler$step()
       }
     }
     self$opt_name <- opt_name

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -435,7 +435,11 @@ luz_callback_lr_scheduler <- luz_callback(
       lr_scheduler(optimizer, ...)
     }
     self[[call_on]] <- function() {
-      self$scheduler$step()
+      if ("metrics" %in% names(formals(scheduler$step))) {
+        scheduler$step(current_loss)
+      } else {
+        scheduler$step()
+      }
     }
     self$opt_name <- opt_name
   },

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -435,7 +435,7 @@ luz_callback_lr_scheduler <- luz_callback(
       lr_scheduler(optimizer, ...)
     }
     self[[call_on]] <- function() {
-      if ("metrics" %in% names(formals(scheduler$step))) {
+      if ("metrics" %in% names(formals(self$scheduler$step))) {
         self$scheduler$step(current_loss)
       } else {
         self$scheduler$step()

--- a/tests/testthat/_snaps/callbacks.md
+++ b/tests/testthat/_snaps/callbacks.md
@@ -13,6 +13,20 @@
       Adjusting learning rate of group 1 to 0.0001
       Adjusting learning rate of group 1 to 0.0000
 
+---
+
+    Code
+      expect_message({
+        output <- mod %>% set_hparams(input_size = 10, output_size = 1) %>% fit(dl,
+          verbose = FALSE, epochs = 20, callbacks = list(luz_callback_lr_scheduler(
+            torch::lr_reduce_on_plateau, verbose = TRUE, patience = 2, threshold = 0.1)))
+      })
+    Message
+      Epoch 7: reducing learning rate of group 1 to 1.0000e-05
+      Epoch 10: reducing learning rate of group 1 to 1.0000e-06
+      Epoch 13: reducing learning rate of group 1 to 1.0000e-07
+      Epoch 16: reducing learning rate of group 1 to 1.0000e-08
+
 # progressbar appears with training and validation
 
     Code

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -29,8 +29,13 @@ test_that("callback lr scheduler", {
     expect_message({
       output <- mod %>%
         set_hparams(input_size = 10, output_size = 1) %>%
-        fit(dl, verbose = FALSE, epochs = 5, callbacks = list(
-          luz_callback_lr_scheduler(torch::lr_reduce_on_plateau, verbose = TRUE)
+        fit(dl, verbose = FALSE, epochs = 20, callbacks = list(
+          luz_callback_lr_scheduler(
+            torch::lr_reduce_on_plateau,
+            verbose = TRUE,
+            patience = 2,
+            threshold = 1e-1
+          )
         ))
     })
   })

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -25,6 +25,16 @@ test_that("callback lr scheduler", {
     })
   })
 
+  expect_snapshot({
+    expect_message({
+      output <- mod %>%
+        set_hparams(input_size = 10, output_size = 1) %>%
+        fit(dl, verbose = FALSE, epochs = 5, callbacks = list(
+          luz_callback_lr_scheduler(torch::lr_reduce_on_plateau, verbose = TRUE)
+        ))
+    })
+  })
+
 })
 
 test_that("csv callback", {


### PR DESCRIPTION
Hi there, I recently came across a small hiccup while using the `luz` package (kudos on the great work! 😃). It seems that when attempting to employ the `reduce_on_plateau` learning rate scheduler, an exception is triggered due to the `luz_callback_lr_scheduler` not factoring in the `current_loss` for specific schedulers. 
This issue bears a resemblance to a similar one I encountered in the tabnet package, https://github.com/mlverse/tabnet/pull/120). I've crafted a corresponding solution and submitted this pull request to solve this bug.
Please let me know if there's anything else I can provide or do to support this pull request.