### PR TITLE
fix few Help typos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: Higher Level 'API' for 'torch'
 Version: 0.4.0.9002
 Authors@R: c(
     person("Daniel", "Falbel", email = "daniel@rstudio.com", role = c("aut", "cre", "cph")),
+    person("Christophe", "Regouby", email = "christophe.regouby@free.fr", role = c("ctb")),
     person(family = "RStudio", role = c("cph"))
     )
 Description: A high level interface for 'torch' providing utilities to reduce the

--- a/R/callbacks-resume.R
+++ b/R/callbacks-resume.R
@@ -131,7 +131,7 @@ luz_callback_auto_resume <- luz_callback(
 #' Allow resume model training from a specific checkpoint
 #'
 #' @param path Path to the checkpoint that you want to resume.
-#' @param restore_model_state Wether to restore the model state from the callback.
+#' @param restore_model_state Wether to restore the model state from the checkpoint.
 #' @param restore_records Wether to restore records from the checkpoint.
 #' @param restore_optimizer_state Wether to restore the optimizer state from the
 #'   checkpoint.

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -382,7 +382,7 @@ luz_callback_metrics <- luz_callback(
 #' - `ctx$loss`: Resets the `loss` attribute to `list()` when finished training/ or
 #'   validating.
 #'
-#' @note In general you won't need to explicitly use the metrics callback as it's
+#' @note In general you won't need to explicitly use the train_valid callback as it's
 #' used by default in [fit.luz_module_generator()].
 #'
 #' @returns

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -466,7 +466,7 @@ luz_callback_lr_scheduler <- luz_callback(
 
 #' CSV logger callback
 #'
-#' Logs metrics obtained during training a fiel on disk.
+#' Logs metrics obtained during training a file on disk.
 #' The file will have 1 line for each epoch/validation.
 #'
 #' @param path path to a file on disk.

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -84,7 +84,7 @@ default_evaluate_callbacks <- function() {
 #' @section Prediction callbacks:
 #'
 #' You can also use callbacks when using [predict()]. In this case the supported
-#' callback methods are detailed above.
+#' callback methods are detailed below:
 #'
 #' ```
 #' Start predict

--- a/R/context.R
+++ b/R/context.R
@@ -79,7 +79,7 @@ context <- R6::R6Class(
       invisible(self)
     },
     #' @description
-    #' Log a metric gen its name and value.
+    #' Log a metric by its name and value.
     #' Metric values are indexed by epoch.
     log_metric = function(name, value) {
       set <- if (self$training) "train" else "valid"

--- a/R/context.R
+++ b/R/context.R
@@ -17,7 +17,6 @@ NULL
 #' See also [ctx].
 #'
 #' @param name name of the metric
-#' @param value value to log
 #' @param what (string) What you are logging.
 #' @param set (string) Usually 'train' or 'valid' indicating the set you want
 #'  to log to. But can be arbitrary info.

--- a/R/context.R
+++ b/R/context.R
@@ -20,7 +20,7 @@ NULL
 #' @param value value to log
 #' @param what (string) What you are logging.
 #' @param set (string) Usually 'train' or 'valid' indicating the set you want
-#'  to lot to. But can be arbitrary info.
+#'  to log to. But can be arbitrary info.
 #' @param value Arbitrary value to log.
 #' @param index Index that this value should be logged. If `NULL` the value
 #'  is added to the end of list, otherwise the index is used.

--- a/R/serialization.R
+++ b/R/serialization.R
@@ -13,7 +13,7 @@
 #'
 #' @param obj an object of class 'luz_module_fitted' as returned by
 #' [fit.luz_module_generator()].
-#' @param path path in file system so save the object.
+#' @param path path in file system to the object.
 #' @param ... currently unused.
 #'
 #' @family luz_save

--- a/R/serialization.R
+++ b/R/serialization.R
@@ -137,7 +137,7 @@ luz_checkpoint <- function(ctx, path) {
 #'
 #' Works with checkpoints created typically with [luz_callback_model_checkpoint()].
 #'
-#' @param obj Object to which we want to laod the checkpoint.
+#' @param obj Object to which we want to load the checkpoint.
 #' @param path Path of the checkpoint on disk.
 #' @param ... unused. Is there to allow future extensions.
 #'

--- a/man/context.Rd
+++ b/man/context.Rd
@@ -161,7 +161,7 @@ is overwritten in favor of the new value.}
 \if{html}{\out{<a id="method-luz_context-log_metric"></a>}}
 \if{latex}{\out{\hypertarget{method-luz_context-log_metric}{}}}
 \subsection{Method \code{log_metric()}}{
-Log a metric gen its name and value.
+Log a metric by its name and value.
 Metric values are indexed by epoch.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{context$log_metric(name, value)}\if{html}{\out{</div>}}

--- a/man/context.Rd
+++ b/man/context.Rd
@@ -143,7 +143,7 @@ Allows logging arbitrary information in the \code{ctx}.
 \item{\code{what}}{(string) What you are logging.}
 
 \item{\code{set}}{(string) Usually 'train' or 'valid' indicating the set you want
-to lot to. But can be arbitrary info.}
+to log to. But can be arbitrary info.}
 
 \item{\code{value}}{value to log}
 
@@ -196,7 +196,7 @@ Get a specific value from the log.
 \item{\code{what}}{(string) What you are logging.}
 
 \item{\code{set}}{(string) Usually 'train' or 'valid' indicating the set you want
-to lot to. But can be arbitrary info.}
+to log to. But can be arbitrary info.}
 
 \item{\code{index}}{Index that this value should be logged. If \code{NULL} the value
 is added to the end of list, otherwise the index is used.}
@@ -217,7 +217,7 @@ Get all metric given an epoch and set.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{set}}{(string) Usually 'train' or 'valid' indicating the set you want
-to lot to. But can be arbitrary info.}
+to log to. But can be arbitrary info.}
 
 \item{\code{epoch}}{The epoch you want to extract metrics from.}
 }
@@ -239,7 +239,7 @@ Get the value of a metric given its name, epoch and set.
 \item{\code{name}}{name of the metric}
 
 \item{\code{set}}{(string) Usually 'train' or 'valid' indicating the set you want
-to lot to. But can be arbitrary info.}
+to log to. But can be arbitrary info.}
 
 \item{\code{epoch}}{The epoch you want to extract metrics from.}
 }
@@ -259,7 +259,7 @@ Get formatted metrics values
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{set}}{(string) Usually 'train' or 'valid' indicating the set you want
-to lot to. But can be arbitrary info.}
+to log to. But can be arbitrary info.}
 
 \item{\code{epoch}}{The epoch you want to extract metrics from.}
 }

--- a/man/context.Rd
+++ b/man/context.Rd
@@ -145,8 +145,6 @@ Allows logging arbitrary information in the \code{ctx}.
 \item{\code{set}}{(string) Usually 'train' or 'valid' indicating the set you want
 to log to. But can be arbitrary info.}
 
-\item{\code{value}}{value to log}
-
 \item{\code{value}}{Arbitrary value to log.}
 
 \item{\code{index}}{Index that this value should be logged. If \code{NULL} the value
@@ -173,8 +171,6 @@ Metric values are indexed by epoch.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{name}}{name of the metric}
-
-\item{\code{value}}{value to log}
 
 \item{\code{value}}{Arbitrary value to log.}
 }

--- a/man/luz_callback.Rd
+++ b/man/luz_callback.Rd
@@ -121,7 +121,7 @@ callback \emph{breakpoints}:
 End Fit
 }\if{html}{\out{</div>}}
 
-Every step market with \verb{on_*} is a point in the training procedure that
+Every step marked with \verb{on_*} is a point in the training procedure that
 is available for callbacks to be called.
 
 The other important part of callbacks is the \code{ctx} (context) object. See
@@ -141,7 +141,7 @@ we want to run it as the last thing in the loop.
 
 
 You can also use callbacks when using \code{\link[=predict]{predict()}}. In this case the supported
-callback methods are detailed above.
+callback methods are detailed below:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{Start predict
  - on_predict_begin

--- a/man/luz_callback_csv_logger.Rd
+++ b/man/luz_callback_csv_logger.Rd
@@ -10,11 +10,12 @@ luz_callback_csv_logger(path)
 \item{path}{path to a file on disk.}
 }
 \description{
-Logs metrics obtained during training a fiel on disk.
+Logs metrics obtained during training a file on disk.
 The file will have 1 line for each epoch/validation.
 }
 \seealso{
 Other luz_callbacks: 
+\code{\link{luz_callback}()},
 \code{\link{luz_callback_auto_resume}()},
 \code{\link{luz_callback_early_stopping}()},
 \code{\link{luz_callback_interrupt}()},
@@ -27,7 +28,6 @@ Other luz_callbacks:
 \code{\link{luz_callback_profile}()},
 \code{\link{luz_callback_progress}()},
 \code{\link{luz_callback_resume_from_checkpoint}()},
-\code{\link{luz_callback_train_valid}()},
-\code{\link{luz_callback}()}
+\code{\link{luz_callback_train_valid}()}
 }
 \concept{luz_callbacks}

--- a/man/luz_callback_resume_from_checkpoint.Rd
+++ b/man/luz_callback_resume_from_checkpoint.Rd
@@ -18,7 +18,7 @@ luz_callback_resume_from_checkpoint(
 
 \item{...}{currently unused.}
 
-\item{restore_model_state}{Wether to restore the model state from the callback.}
+\item{restore_model_state}{Wether to restore the model state from the checkpoint.}
 
 \item{restore_records}{Wether to restore records from the checkpoint.}
 
@@ -39,6 +39,7 @@ information.
 \code{\link[=luz_callback_model_checkpoint]{luz_callback_model_checkpoint()}}
 
 Other luz_callbacks: 
+\code{\link{luz_callback}()},
 \code{\link{luz_callback_auto_resume}()},
 \code{\link{luz_callback_csv_logger}()},
 \code{\link{luz_callback_early_stopping}()},
@@ -51,7 +52,6 @@ Other luz_callbacks:
 \code{\link{luz_callback_model_checkpoint}()},
 \code{\link{luz_callback_profile}()},
 \code{\link{luz_callback_progress}()},
-\code{\link{luz_callback_train_valid}()},
-\code{\link{luz_callback}()}
+\code{\link{luz_callback_train_valid}()}
 }
 \concept{luz_callbacks}

--- a/man/luz_callback_train_valid.Rd
+++ b/man/luz_callback_train_valid.Rd
@@ -24,11 +24,12 @@ validating.
 }
 }
 \note{
-In general you won't need to explicitly use the metrics callback as it's
+In general you won't need to explicitly use the train_valid callback as it's
 used by default in \code{\link[=fit.luz_module_generator]{fit.luz_module_generator()}}.
 }
 \seealso{
 Other luz_callbacks: 
+\code{\link{luz_callback}()},
 \code{\link{luz_callback_auto_resume}()},
 \code{\link{luz_callback_csv_logger}()},
 \code{\link{luz_callback_early_stopping}()},
@@ -41,7 +42,6 @@ Other luz_callbacks:
 \code{\link{luz_callback_model_checkpoint}()},
 \code{\link{luz_callback_profile}()},
 \code{\link{luz_callback_progress}()},
-\code{\link{luz_callback_resume_from_checkpoint}()},
-\code{\link{luz_callback}()}
+\code{\link{luz_callback_resume_from_checkpoint}()}
 }
 \concept{luz_callbacks}

--- a/man/luz_load.Rd
+++ b/man/luz_load.Rd
@@ -7,7 +7,7 @@
 luz_load(path)
 }
 \arguments{
-\item{path}{path in file system so save the object.}
+\item{path}{path in file system to the object.}
 }
 \description{
 Loads a fitted model. See documentation in \code{\link[=luz_save]{luz_save()}}.

--- a/man/luz_load_checkpoint.Rd
+++ b/man/luz_load_checkpoint.Rd
@@ -7,7 +7,7 @@
 luz_load_checkpoint(obj, path, ...)
 }
 \arguments{
-\item{obj}{Object to which we want to laod the checkpoint.}
+\item{obj}{Object to which we want to load the checkpoint.}
 
 \item{path}{Path of the checkpoint on disk.}
 

--- a/man/luz_save.Rd
+++ b/man/luz_save.Rd
@@ -10,7 +10,7 @@ luz_save(obj, path, ...)
 \item{obj}{an object of class 'luz_module_fitted' as returned by
 \code{\link[=fit.luz_module_generator]{fit.luz_module_generator()}}.}
 
-\item{path}{path in file system so save the object.}
+\item{path}{path in file system to the object.}
 
 \item{...}{currently unused.}
 }

--- a/man/rmd/callbacks.Rmd
+++ b/man/rmd/callbacks.Rmd
@@ -73,7 +73,7 @@ Here's an overview of possible callback *breakpoints*:
        - on_fit_end
     End Fit
 
-Every step market with `on_*` is a point in the training procedure that is available for callbacks to be called.
+Every step marked with `on_*` is a point in the training procedure that is available for callbacks to be called.
 
 The other important part of callbacks is the `ctx` (context) object. 
 See `help("ctx")` for details.


### PR DESCRIPTION
Hello, 

translating Help is a very good occation to fix typos.

Here is the side effect of [luz.fr](https://github.com/cregouby/luz.fr)