### PR TITLE
Add `.getbatch` to dataloaders that inherits mnist_dataset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # luz (development version)
 
+* override `.getbatch()` method in examples with `mnist_dataset`. (@cregouby #160)
+
 # luz 0.5.1
 
 * fixed a bug preventing additional arguments passed to `predict` to be forwarded to `model$predict` (#157)

--- a/vignettes/examples/mnist-autoencoder.Rmd
+++ b/vignettes/examples/mnist-autoencoder.Rmd
@@ -21,7 +21,7 @@ mnist_dataset2 <- torch::dataset(
     output <- super$.getitem(i)
     output$y <- output$x
     output
-  }
+  },
   .getbatch = function(i) {
     output <- super$.getbatch(i)
     output$y <- output$x

--- a/vignettes/examples/mnist-autoencoder.Rmd
+++ b/vignettes/examples/mnist-autoencoder.Rmd
@@ -22,7 +22,11 @@ mnist_dataset2 <- torch::dataset(
     output$y <- output$x
     output
   }
-)
+  .getbatch = function(i) {
+    output <- super$.getbatch(i)
+    output$y <- output$x
+    output
+  })
 
 train_ds <- mnist_dataset2(
   dir,

--- a/vignettes/examples/mnist-triplet.Rmd
+++ b/vignettes/examples/mnist-triplet.Rmd
@@ -49,9 +49,9 @@ triplet_mnist_dataset <- dataset(
 
     list(
       list( # input is a list with 3 images.
-        anchor = self$transform(self$data[indices, , ])$unsqueeze(2),
-        negative = self$transform(self$data[neg_idx, , ])$unsqueeze(2),
-        positive = self$transform(self$data[pos_idx, , ])$unsqueeze(2)
+        anchor = self$transform(self$data[indices, , ])$permute(c(2,1,3))$unsqueeze(2),
+        negative = self$transform(self$data[neg_idx, , ])$permute(c(2,1,3))$unsqueeze(2),
+        positive = self$transform(self$data[pos_idx, , ])$permute(c(2,1,3))$unsqueeze(2)
       ),
       list() # no 'target'
     )

--- a/vignettes/examples/mnist-triplet.Rmd
+++ b/vignettes/examples/mnist-triplet.Rmd
@@ -16,6 +16,11 @@ dir <- "./mnist" # caching directory
 
 triplet_mnist_dataset <- dataset(
   inherit = mnist_dataset,
+  initialize = function(...) {
+    super$initialize(...)
+    self$targets_vec <- as.integer(self$targets)
+  },
+  
   .getitem = function(index) {
     anchor <- self$data[index, ,]
     label <- self$targets[index]
@@ -28,6 +33,25 @@ triplet_mnist_dataset <- dataset(
         anchor = self$transform(anchor),
         negative = self$transform(negative),
         positive = self$transform(positive)
+      ),
+      list() # no 'target'
+    )
+  },
+
+  .getbatch = function(indices) {
+    safe_sample <- function(x) {
+      if (length(x) <= 1) return(x)
+      sample(x, 1)
+    }
+    labels <- self$targets_vec[indices]
+    pos_idx <- vapply(labels, function(l) safe_sample(which(self$targets_vec == l)), 1L)
+    neg_idx <- vapply(labels, function(l) safe_sample(which(self$targets_vec != l)), 1L)
+
+    list(
+      list( # input is a list with 3 images.
+        anchor = self$transform(self$data[indices, , ])$unsqueeze(2),
+        negative = self$transform(self$data[neg_idx, , ])$unsqueeze(2),
+        positive = self$transform(self$data[pos_idx, , ])$unsqueeze(2)
       ),
       list() # no 'target'
     )


### PR DESCRIPTION
As `torchvision::mnist_dataset()` will [eventually](https://github.com/mlverse/torchvision/issue/309) get a .getbatch() method,  this pull request overide .getbatch() when requires in luz exemples.

I fully agree that the code looks awful for a pedagogic example, but as we don't (want to ) add a torchvision>= 0.9 constraint, we need exemples using mnist_dataset() to have
- redefinition of .getitem(), used by users with torchvision <= 0.8 
- redefinition of .getbatch(), used by users with torchvision >= 0.9 

This is an alternative fix for https://github.com/mlverse/torchvision/issues/263 with `torchvision::mnist_dataset()` having `.getbatch()` method.
